### PR TITLE
Refactor: Adjust services section to display 4 cards per row

### DIFF
--- a/css/new-style.css
+++ b/css/new-style.css
@@ -337,7 +337,7 @@ section {
 
 .hero-content h1 {
     font-size: 2.8rem;
-    font-weight: 600; /* Reduced font weight for elegance */
+    font-weight: 600;
     color: #FFFFFF;
     line-height: 1.2;
     margin-bottom: 0.5em;
@@ -351,7 +351,7 @@ section {
 
 .typing-cursor {
     color: #63ccc5;
-    font-weight: 600; /* Match new h1 weight */
+    font-weight: 600;
     animation: blinkCursor 0.7s infinite;
 }
 
@@ -470,9 +470,23 @@ section {
 /* Services Section */
 .services-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    /* grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); Original */
+    grid-template-columns: repeat(4, 1fr); /* For 4 items in a row on desktop */
     gap: 2rem;
 }
+
+@media (max-width: 1024px) { /* Tablet view */
+    .services-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 576px) { /* Mobile view */
+    .services-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
 
 .service-card {
     background-color: #fff;
@@ -750,9 +764,7 @@ section {
         display: none;
     }
 
-    .services-grid {
-        grid-template-columns: 1fr;
-    }
+    /* .services-grid is handled by its own media queries now */
     .portfolio-grid {
         grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     }


### PR DESCRIPTION
- Modified CSS for .services-grid to use repeat(4, 1fr) on desktop.
- Updated media queries for tablet (2 cards per row) and mobile (1 card per row) for responsive stacking.